### PR TITLE
fix: use correct API endpoint for reading tasks

### DIFF
--- a/src/ticktick-client.ts
+++ b/src/ticktick-client.ts
@@ -48,7 +48,7 @@ export class TickTickClient {
   async getTask(projectId: string, taskId: string): Promise<unknown> {
     return this.request(
       'GET',
-      `/task/${encodeURIComponent(projectId)}/${encodeURIComponent(taskId)}`,
+      `/project/${encodeURIComponent(projectId)}/task/${encodeURIComponent(taskId)}`,
     );
   }
 

--- a/tests/unit/client.test.ts
+++ b/tests/unit/client.test.ts
@@ -75,6 +75,19 @@ describe('TickTickClient', () => {
       await expect(client.getProjects()).rejects.toThrow(TickTickRateLimitError);
     });
 
+    it('getTask uses /project/{pid}/task/{tid} endpoint', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        text: () => Promise.resolve(JSON.stringify({ id: 't1', title: 'Test', projectId: 'inbox123' })),
+      });
+
+      await client.getTask('inbox123', 't1');
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://api.ticktick.com/open/v1/project/inbox123/task/t1',
+        expect.objectContaining({ method: 'GET' }),
+      );
+    });
+
     it('throws TickTickApiError on 500', async () => {
       mockFetch.mockResolvedValue({
         ok: false,


### PR DESCRIPTION
## Summary

- Fix `getTask` to use `GET /project/{pid}/task/{tid}` instead of `GET /task/{pid}/{tid}`
- The incorrect path caused 404 errors for Inbox tasks (and potentially other projects)
- Add unit test verifying the correct endpoint path

Closes #1

## Test Plan
- [x] Unit test added asserting correct URL path for `getTask`
- [x] All 41 existing tests pass
- [ ] Manual verification: create an Inbox task, then read it back with `ticktick_get_task`

🤖 Generated with [Claude Code](https://claude.ai/code)