### PR TITLE
feat: Docker sandbox for Claude Code YOLO mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,8 +7,6 @@ dist/
 
 # Local config
 .mcp.json
-docker-compose.yml
-docker/
 
 # IDE
 .idea/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,93 @@
+# Claude Code Sandboxed Development Container
+#
+# Usage:
+#   docker compose build                                      # build the image
+#   docker compose run --rm claude                            # interactive YOLO session
+#   docker compose run --rm claude -p "fix the auth bug"      # one-shot prompt
+#   docker compose run --rm -e SKIP_FIREWALL=1 claude         # without network restrictions
+#   docker compose run --rm -e EXTRA_DOMAINS="pypi.org" claude  # add allowed domains
+#
+# Required:
+#   ANTHROPIC_API_KEY must be set in your shell or in a .env file
+#
+# Linux users: set USER_UID and USER_GID to match your host user:
+#   USER_UID=1000 USER_GID=1000 docker compose build
+
+services:
+  claude:
+    build:
+      context: ./docker
+      dockerfile: Dockerfile
+      args:
+        CLAUDE_CODE_VERSION: latest
+        # Match your host user to avoid bind-mount permission issues.
+        # macOS default: UID=501 GID=20. Linux: typically UID=1000 GID=1000.
+        USER_UID: ${USER_UID:-501}
+        USER_GID: ${USER_GID:-20}
+    stdin_open: true
+    tty: true
+    init: true              # tini as PID 1 for proper signal forwarding + zombie reaping
+    restart: "no"           # interactive tool, not a long-running service
+
+    # ── Security hardening ─────────────────────────────────────────────
+    cap_drop:
+      - ALL
+    cap_add:
+      - NET_ADMIN                 # required: iptables firewall setup (init only)
+      - NET_RAW                   # required: iptables firewall setup (init only)
+      - SETUID                    # required: gosu privilege drop (root → claude)
+      - SETGID                    # required: gosu privilege drop (root → claude)
+      - CHOWN                     # required: fix ownership of tmpfs mounts at init
+      - DAC_OVERRIDE              # required: entrypoint root operations on tmpfs
+    security_opt:
+      - no-new-privileges:true    # prevents claude user from regaining root
+    read_only: true               # immutable root filesystem
+
+    # ── Writable areas (tmpfs — ephemeral, not persisted) ──────────────
+    # /home/claude is tmpfs so .gitconfig, .bashrc etc. are writable.
+    # The .claude volume mount (below) layers on top for persistent state.
+    tmpfs:
+      - /tmp:rw,nosuid,size=1g
+      - /home/claude:rw,nosuid,size=512m
+      - /run:rw,noexec,nosuid,size=64m
+
+    # ── Volumes ────────────────────────────────────────────────────────
+    volumes:
+      # Project repo — the only rw bind mount.
+      # SECURITY: Claude Code can read/write all files here including .git/config.
+      # Run `git diff` after every session to review changes.
+      - .:/workspace:rw
+
+      # Claude Code state (persists across sessions)
+      - claude-config:/home/claude/.claude
+
+      # Optional: mount host claude settings read-only (uncomment to use)
+      # - ${HOME}/.claude/settings.json:/home/claude/.claude/settings.json:ro
+
+    # ── Environment ────────────────────────────────────────────────────
+    environment:
+      - ANTHROPIC_API_KEY               # required — from host env or .env file
+      - NODE_OPTIONS=--max-old-space-size=4096
+      # EXTRA_DOMAINS: pass at runtime to whitelist additional domains:
+      #   docker compose run --rm -e EXTRA_DOMAINS="pypi.org,custom.api.com" claude
+      # SKIP_FIREWALL: pass at runtime to disable network restrictions:
+      #   docker compose run --rm -e SKIP_FIREWALL=1 claude
+
+    # ── Resource limits ────────────────────────────────────────────────
+    deploy:
+      resources:
+        limits:
+          cpus: "4"
+          memory: 8g
+          pids: 512
+
+    # ── Logging ────────────────────────────────────────────────────────
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
+
+volumes:
+  claude-config:
+    name: claude-code-config

--- a/docker/.dockerignore
+++ b/docker/.dockerignore
@@ -1,0 +1,5 @@
+# Only send the 3 required files as Docker build context
+*
+!Dockerfile
+!entrypoint.sh
+!init-firewall.sh

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,84 @@
+# Claude Code Sandboxed Development Container
+# Runs Claude Code in YOLO mode (--dangerously-skip-permissions) with:
+#   - Network egress restricted to whitelisted domains via iptables
+#   - Non-root execution after firewall init
+#   - Read-only root filesystem (writable dirs via tmpfs/volumes)
+#
+# Usage:
+#   docker compose run --rm claude              # interactive session
+#   docker compose run --rm claude -p "prompt"  # one-shot prompt
+#
+# Based on: https://github.com/anthropics/claude-code/tree/main/.devcontainer
+
+FROM node:22-bookworm-slim
+
+LABEL org.opencontainers.image.title="claude-code-sandbox"
+LABEL org.opencontainers.image.description="Sandboxed Claude Code with network egress restrictions"
+
+ARG CLAUDE_CODE_VERSION=latest
+
+# ── System dependencies ──────────────────────────────────────────────
+# git              : Claude Code repo operations
+# curl, ca-certs   : HTTPS, firewall verification
+# gosu             : PID-1-safe privilege de-escalation (setuid/setgid + exec)
+# jq               : JSON processing for firewall setup
+# aggregate        : CIDR aggregation for GitHub IP ranges (Debian package)
+# iptables, ipset  : network firewall rules and IP sets
+# iproute2         : `ip route` for detecting Docker gateway
+# dnsutils         : `dig` for DNS resolution in firewall setup
+# less, procps     : basic utilities Claude Code may invoke
+#
+# NOTE: sudo is intentionally NOT installed. The entrypoint runs as root
+# for firewall init, then drops to non-root via gosu. no-new-privileges
+# prevents the claude user from regaining root, making sudo inert anyway.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    git \
+    curl \
+    ca-certificates \
+    gosu \
+    jq \
+    less \
+    procps \
+    iptables \
+    ipset \
+    iproute2 \
+    dnsutils \
+    aggregate \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/*
+
+# ── Install Claude Code ──────────────────────────────────────────────
+RUN npm install -g @anthropic-ai/claude-code@${CLAUDE_CODE_VERSION} \
+  && npm cache clean --force \
+  && rm -rf /root/.npm /tmp/*
+
+# ── Non-root user ────────────────────────────────────────────────────
+# Match host UID/GID to avoid bind-mount permission issues.
+# macOS default: 501:20. Linux default: 1000:1000.
+# GID 20 exists in Debian as 'dialout', so we use the existing group if present.
+ARG USER_UID=501
+ARG USER_GID=20
+RUN if ! getent group ${USER_GID} >/dev/null 2>&1; then \
+      groupadd -g ${USER_GID} claude; \
+    fi \
+  && useradd -u ${USER_UID} -g ${USER_GID} -m -s /bin/bash claude
+
+# ── Directories ──────────────────────────────────────────────────────
+RUN mkdir -p /workspace /home/claude/.claude /home/claude/.npm \
+  && chown -R ${USER_UID}:${USER_GID} /workspace /home/claude
+
+# ── Firewall + Entrypoint ────────────────────────────────────────────
+COPY init-firewall.sh entrypoint.sh /usr/local/bin/
+RUN chmod +x /usr/local/bin/init-firewall.sh /usr/local/bin/entrypoint.sh
+
+# NOTE: No sudoers entry. The entrypoint runs as root for firewall init,
+# then drops to the claude user via gosu. The no-new-privileges Docker
+# flag prevents the claude user from ever regaining root.
+
+# ── Runtime config ───────────────────────────────────────────────────
+WORKDIR /workspace
+ENV HOME=/home/claude
+ENV DEVCONTAINER=true
+
+# Container starts as root for firewall init, then drops to claude user
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+set -euo pipefail
+
+log() { echo "[$(date '+%H:%M:%S')] $*"; }
+
+# ── Validate required environment ────────────────────────────────────
+if [ -z "${ANTHROPIC_API_KEY:-}" ]; then
+    log "ERROR: ANTHROPIC_API_KEY is not set."
+    log "  Export it in your shell:  export ANTHROPIC_API_KEY=sk-ant-..."
+    log "  Or add it to a .env file: echo 'ANTHROPIC_API_KEY=sk-ant-...' > .env"
+    exit 1
+fi
+
+# ── Firewall ─────────────────────────────────────────────────────────
+if [ "${SKIP_FIREWALL:-0}" = "1" ]; then
+    log "WARNING: SKIP_FIREWALL=1 — ALL NETWORK RESTRICTIONS DISABLED"
+    log "  This should only be used for debugging, never for untrusted repos."
+    sleep 2
+else
+    log "Initializing network firewall..."
+    if /usr/local/bin/init-firewall.sh; then
+        log "Firewall active: egress restricted to allowed domains"
+    else
+        log "ERROR: Firewall setup failed."
+        log "  To run without network restrictions: docker compose run --rm -e SKIP_FIREWALL=1 claude"
+        exit 1
+    fi
+fi
+
+# ── Resolve the claude user's UID ─────────────────────────────────────
+CLAUDE_UID=$(id -u claude)
+CLAUDE_GID=$(id -g claude)
+
+# ── Fix ownership of home tmpfs and config volume ────────────────────
+# The /home/claude tmpfs is root-owned by default; fix before any gosu calls.
+chown "$CLAUDE_UID:$CLAUDE_GID" /home/claude
+chown -R "$CLAUDE_UID:$CLAUDE_GID" /home/claude/.claude 2>/dev/null || true
+
+# ── Git safe directory ───────────────────────────────────────────────
+# Mounted repos may have different ownership — tell git it's OK
+gosu claude git config --global safe.directory /workspace
+
+# ── Drop to non-root and exec Claude Code ────────────────────────────
+log "Starting Claude Code (user=claude, uid=$CLAUDE_UID)"
+echo ""
+exec gosu claude claude --dangerously-skip-permissions "$@"

--- a/docker/init-firewall.sh
+++ b/docker/init-firewall.sh
@@ -1,0 +1,178 @@
+#!/bin/bash
+set -euo pipefail
+IFS=$'\n\t'
+
+# ══════════════════════════════════════════════════════════════════════
+# Network Egress Firewall for Claude Code Container
+# ══════════════════════════════════════════════════════════════════════
+# Default-deny outbound policy. Only whitelisted domains are reachable.
+# Adapted from Anthropic's official devcontainer:
+#   https://github.com/anthropics/claude-code/tree/main/.devcontainer
+#
+# SECURITY NOTES:
+# - DNS is restricted to Docker's embedded resolver (127.0.0.11) to
+#   prevent DNS tunneling exfiltration.
+# - SSH is restricted to whitelisted IPs only (GitHub).
+# - The host bridge network is limited to the gateway IP, not the /24.
+# - There is a brief (~seconds) unrestricted window during init between
+#   iptables flush and default-deny policy. This is an accepted trade-off
+#   inherited from the official devcontainer approach.
+#
+# To add project-specific domains, pass EXTRA_DOMAINS env var:
+#   EXTRA_DOMAINS="pypi.org,custom.api.com" docker compose run --rm claude
+# ══════════════════════════════════════════════════════════════════════
+
+# ── Hardening: ignore inherited env for security ─────────────────────
+# Prevent the claude user from influencing firewall config via sudo env.
+# (sudo is not installed, but defense in depth.)
+EXTRA_DOMAINS_VAL="${EXTRA_DOMAINS:-}"
+unset SKIP_FIREWALL
+
+# ── Allowed domains ──────────────────────────────────────────────────
+CORE_DOMAINS=(
+    "api.anthropic.com"         # Claude API (required)
+    "statsig.anthropic.com"     # Anthropic telemetry
+    "api.statsig.com"           # Statsig alternative endpoint
+    "statsig.com"               # Feature flags
+    "sentry.io"                 # Error reporting
+    "registry.npmjs.org"        # npm package registry
+    "updates.anthropic.com"     # Claude Code version checks
+)
+
+# Project-specific domains from EXTRA_DOMAINS env var (comma-separated)
+EXTRA_ALLOWED_DOMAINS=()
+if [ -n "$EXTRA_DOMAINS_VAL" ]; then
+    IFS=',' read -ra _extra <<< "$EXTRA_DOMAINS_VAL"
+    for d in "${_extra[@]}"; do
+        EXTRA_ALLOWED_DOMAINS+=("$(echo "$d" | xargs)")  # trim whitespace
+    done
+fi
+
+ALL_DOMAINS=("${CORE_DOMAINS[@]}" "${EXTRA_ALLOWED_DOMAINS[@]}")
+
+# ── Docker embedded DNS ──────────────────────────────────────────────
+DOCKER_DNS="127.0.0.11"
+
+# ── 1. Preserve Docker DNS NAT rules before flushing ─────────────────
+DOCKER_DNS_RULES=$(iptables-save -t nat | grep "127\.0\.0\.11" || true)
+
+iptables -F
+iptables -X
+iptables -t nat -F
+iptables -t nat -X
+iptables -t mangle -F
+iptables -t mangle -X
+ipset destroy allowed-domains 2>/dev/null || true
+
+# ── 2. Restore Docker internal DNS NAT ───────────────────────────────
+if [ -n "$DOCKER_DNS_RULES" ]; then
+    iptables -t nat -N DOCKER_OUTPUT 2>/dev/null || true
+    iptables -t nat -N DOCKER_POSTROUTING 2>/dev/null || true
+    echo "$DOCKER_DNS_RULES" | xargs -L 1 iptables -t nat
+fi
+
+# ── 3. Allow loopback, restricted DNS, and established connections ───
+# Loopback (required for Docker DNS resolver and local services)
+iptables -A INPUT  -i lo -j ACCEPT
+iptables -A OUTPUT -o lo -j ACCEPT
+
+# DNS restricted to Docker's embedded resolver ONLY (prevents DNS tunneling)
+iptables -A OUTPUT -p udp --dport 53 -d "$DOCKER_DNS" -j ACCEPT
+iptables -A INPUT  -p udp --sport 53 -s "$DOCKER_DNS" -j ACCEPT
+iptables -A OUTPUT -p tcp --dport 53 -d "$DOCKER_DNS" -j ACCEPT
+iptables -A INPUT  -p tcp --sport 53 -s "$DOCKER_DNS" -j ACCEPT
+
+# ── 4. Build allowed IP set ──────────────────────────────────────────
+ipset create allowed-domains hash:net
+
+# GitHub IP ranges (from their meta API) — retry with backoff
+echo "Fetching GitHub IP ranges..."
+gh_ranges=""
+for attempt in 1 2 3; do
+    if gh_ranges=$(curl -sf --connect-timeout 10 --max-time 30 https://api.github.com/meta); then
+        break
+    fi
+    echo "  Attempt $attempt/3 failed, retrying in ${attempt}s..."
+    sleep "$attempt"
+done
+
+if [ -z "$gh_ranges" ]; then
+    echo "WARNING: Failed to fetch GitHub IP ranges after 3 attempts."
+    echo "  GitHub access (git push/pull) will not work."
+    # Degrade gracefully — don't abort the entire container
+else
+    if ! echo "$gh_ranges" | jq -e '.web and .api and .git' >/dev/null 2>&1; then
+        echo "WARNING: GitHub meta response missing required fields (skipping)"
+    else
+        # aggregate -q: merges overlapping CIDRs into a minimal set (Debian 'aggregate' package)
+        while read -r cidr; do
+            [[ "$cidr" =~ ^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}/[0-9]{1,2}$ ]] || continue
+            ipset add allowed-domains "$cidr" 2>/dev/null || true
+        done < <(echo "$gh_ranges" | jq -r '(.web + .api + .git)[]' | aggregate -q)
+    fi
+fi
+
+# Resolve and add each allowed domain
+for domain in "${ALL_DOMAINS[@]}"; do
+    ips=$(dig +noall +answer A "$domain" | awk '$4 == "A" {print $5}')
+    if [ -z "$ips" ]; then
+        echo "WARNING: Failed to resolve $domain (skipping)"
+        continue
+    fi
+    while read -r ip; do
+        [[ "$ip" =~ ^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$ ]] || continue
+        ipset add allowed-domains "$ip" 2>/dev/null || true
+    done < <(echo "$ips")
+done
+
+# NOTE: DNS is resolved once at startup. If CDN IPs rotate during a long
+# session, connections may be blocked. Restart the container to re-resolve.
+
+# ── 5. Allow Docker host gateway (restricted to gateway IP only) ─────
+HOST_IP=$(ip route | grep default | cut -d" " -f3)
+if [ -n "$HOST_IP" ]; then
+    echo "Docker gateway: $HOST_IP"
+    # Only the gateway IP — NOT the entire /24 subnet (prevents lateral movement)
+    iptables -A INPUT  -s "$HOST_IP" -m state --state ESTABLISHED,RELATED -j ACCEPT
+    iptables -A OUTPUT -d "$HOST_IP" -j ACCEPT
+fi
+
+# ── 6. Default-deny + allow only whitelisted egress ──────────────────
+iptables -P INPUT   DROP
+iptables -P FORWARD DROP
+iptables -P OUTPUT  DROP
+
+iptables -A INPUT  -m state --state ESTABLISHED,RELATED -j ACCEPT
+iptables -A OUTPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
+
+# SSH restricted to whitelisted IPs only (GitHub, not arbitrary hosts)
+iptables -A OUTPUT -p tcp --dport 22 -m set --match-set allowed-domains dst -j ACCEPT
+
+# HTTPS to whitelisted IPs
+iptables -A OUTPUT -m set --match-set allowed-domains dst -j ACCEPT
+
+# Reject everything else with immediate feedback (not silent DROP)
+iptables -A OUTPUT -j REJECT --reject-with icmp-admin-prohibited
+
+# ── 7. Verify ────────────────────────────────────────────────────────
+echo "Verifying firewall..."
+
+if curl --connect-timeout 5 -sf https://example.com >/dev/null 2>&1; then
+    echo "  FAIL: example.com is reachable (firewall not working)"
+    exit 1
+fi
+echo "  PASS: Blocked traffic (example.com unreachable)"
+
+if ! curl --connect-timeout 5 -sf https://api.anthropic.com >/dev/null 2>&1; then
+    echo "  WARN: api.anthropic.com unreachable (may need DNS retry)"
+else
+    echo "  PASS: Anthropic API reachable"
+fi
+
+if ! curl --connect-timeout 5 -sf https://github.com >/dev/null 2>&1; then
+    echo "  WARN: github.com unreachable (git operations may fail)"
+else
+    echo "  PASS: GitHub reachable"
+fi
+
+echo "Firewall ready."


### PR DESCRIPTION
## Summary

- Adds a Docker container setup for running Claude Code with `--dangerously-skip-permissions` (YOLO mode) in a hardened sandbox
- iptables firewall restricts network egress to Anthropic API, GitHub, and npm registry only — all other traffic is blocked
- Non-root execution, read-only root filesystem, zero effective capabilities for the claude user, no sudo

## Security Controls

| Control | Implementation |
|---------|---------------|
| Network egress | iptables default-deny, whitelist only (Anthropic, GitHub, npm) |
| DNS tunneling | Restricted to Docker resolver (127.0.0.11) |
| SSH | Restricted to whitelisted IPs (GitHub only) |
| Privilege escalation | `no-new-privileges`, no sudo, zero effective caps |
| Filesystem | Read-only root, workspace bind mount is the only rw area |
| Resources | 4 CPU, 8GB RAM, 512 PIDs max |

## Usage

```bash
docker compose build
export ANTHROPIC_API_KEY=sk-ant-...
docker compose run --rm claude                          # interactive
docker compose run --rm claude -p "fix the auth bug"    # one-shot
```

## Test plan

- [x] Image builds successfully
- [x] Claude Code binary present and reports version
- [x] gosu drops root → claude (uid=501), zero effective capabilities
- [x] Read-only root filesystem blocks writes to /etc, /usr
- [x] Writable: /tmp, /home/claude (tmpfs), .claude volume, workspace
- [x] No sudo installed
- [x] Missing API key → clear error message
- [x] Firewall blocks example.com, evil.com
- [x] Firewall allows api.anthropic.com, github.com, registry.npmjs.org
- [x] DNS tunneling to 8.8.8.8 blocked

🤖 Generated with [Claude Code](https://claude.com/claude-code)