### PR TITLE
feat: inbox support via lazy discovery and data format handling

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,16 +1,10 @@
-import { TokenRefreshResponse } from './types.js';
+import { TokenRefreshResponse, KeychainLike } from './types.js';
 
 export class AuthError extends Error {
   constructor(message: string) {
     super(message);
     this.name = 'AuthError';
   }
-}
-
-interface KeychainLike {
-  get(account: string): Promise<string | null>;
-  set(account: string, password: string): Promise<void>;
-  remove(account: string): Promise<void>;
 }
 
 type FetchFn = typeof globalThis.fetch;

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,7 +20,7 @@ if (!clientId) {
 
 const keychain = new Keychain('ticktick-mcp');
 const tokenManager = new TokenManager(keychain, clientId);
-const ticktickClient = new TickTickClient(tokenManager);
+const ticktickClient = new TickTickClient(tokenManager, keychain);
 
 const server = new McpServer({
   name: 'ticktick-mcp',

--- a/src/ticktick-client.ts
+++ b/src/ticktick-client.ts
@@ -39,7 +39,10 @@ export class TickTickClient {
     }
 
     if (!this.inboxDiscoveryPromise) {
-      this.inboxDiscoveryPromise = this._discoverInboxProjectId();
+      this.inboxDiscoveryPromise = this._discoverInboxProjectId().catch((err) => {
+        this.inboxDiscoveryPromise = null;
+        throw err;
+      });
     }
 
     return this.inboxDiscoveryPromise;

--- a/src/tools/projects.ts
+++ b/src/tools/projects.ts
@@ -26,11 +26,15 @@ export function registerProjectTools(server: McpServer, client: TickTickClient):
           const alreadyIncluded = (projects as Array<{ id: string }>).some((p) => p.id === inboxId);
           if (!alreadyIncluded) {
             const inboxData = await client.getProjectData(inboxId);
-            const parsed = inboxData && typeof inboxData === 'object' && 'project' in inboxData
-              ? (inboxData as { project: unknown }).project
-              : null;
-            if (parsed) {
-              return success([parsed, ...(projects as unknown[])]);
+            let inboxProject: unknown = null;
+            if (inboxData && typeof inboxData === 'object' && 'project' in inboxData) {
+              inboxProject = (inboxData as { project: unknown }).project;
+            } else {
+              // Inbox API returns { tasks: [...] } without project metadata — synthesize it
+              inboxProject = { id: inboxId, name: 'Inbox' };
+            }
+            if (inboxProject) {
+              return success([inboxProject, ...(projects as unknown[])]);
             }
           }
         } catch {

--- a/src/tools/tasks.ts
+++ b/src/tools/tasks.ts
@@ -120,6 +120,20 @@ export function registerTaskTools(server: McpServer, client: TickTickClient): vo
           if (failedProjectCount > 0) {
             warnings.push(`${failedProjectCount} project(s) could not be parsed and were skipped`);
           }
+
+          // Also fetch inbox tasks
+          try {
+            const inboxId = await client.getInboxProjectId();
+            const inboxData = await client.getProjectData(inboxId);
+            const inboxParsed = TickTickProjectDataRaw.safeParse(inboxData);
+            if (inboxParsed.success) {
+              allTasks.push(...inboxParsed.data.tasks);
+            } else {
+              warnings.push('Inbox tasks could not be parsed and were skipped');
+            }
+          } catch {
+            warnings.push('Could not fetch inbox tasks — inbox discovery failed');
+          }
         }
 
         let failedTaskCount = 0;

--- a/src/tools/tasks.ts
+++ b/src/tools/tasks.ts
@@ -124,12 +124,15 @@ export function registerTaskTools(server: McpServer, client: TickTickClient): vo
           // Also fetch inbox tasks
           try {
             const inboxId = await client.getInboxProjectId();
-            const inboxData = await client.getProjectData(inboxId);
-            const inboxParsed = TickTickProjectDataRaw.safeParse(inboxData);
-            if (inboxParsed.success) {
-              allTasks.push(...inboxParsed.data.tasks);
-            } else {
-              warnings.push('Inbox tasks could not be parsed and were skipped');
+            const alreadyFetched = projects.some((p) => p.id === inboxId);
+            if (!alreadyFetched) {
+              const inboxData = await client.getProjectData(inboxId);
+              const inboxParsed = TickTickProjectDataRaw.safeParse(inboxData);
+              if (inboxParsed.success) {
+                allTasks.push(...inboxParsed.data.tasks);
+              } else {
+                warnings.push('Inbox tasks could not be parsed and were skipped');
+              }
             }
           } catch {
             warnings.push('Could not fetch inbox tasks — inbox discovery failed');

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,13 @@
 import { z } from 'zod';
 
+// --- Shared interfaces ---
+
+export interface KeychainLike {
+  get(account: string): Promise<string | null>;
+  set(account: string, password: string): Promise<void>;
+  remove(account: string): Promise<void>;
+}
+
 // --- Input schemas (tool parameters) ---
 
 export const CreateTaskInput = z.object({

--- a/tests/integration/spike-tags.test.ts
+++ b/tests/integration/spike-tags.test.ts
@@ -25,7 +25,7 @@ describe.skipIf(SKIP)('Integration: Tag Support Spike', () => {
   const clientId = process.env.TICKTICK_CLIENT_ID!;
   const keychain = new Keychain('ticktick-mcp');
   const tokenManager = new TokenManager(keychain, clientId);
-  const client = new TickTickClient(tokenManager);
+  const client = new TickTickClient(tokenManager, keychain);
 
   let createdTaskId: string | undefined;
   let projectId: string | undefined;

--- a/tests/mcp/server.test.ts
+++ b/tests/mcp/server.test.ts
@@ -14,6 +14,7 @@ function createMockClient() {
     getTask: vi.fn().mockResolvedValue({ id: 't1', title: 'Test', projectId: 'p1', status: 0 }),
     updateTask: vi.fn().mockResolvedValue({ id: 't1', title: 'Updated' }),
     completeTask: vi.fn().mockResolvedValue(null),
+    getInboxProjectId: vi.fn().mockResolvedValue('inbox123'),
   };
 }
 
@@ -94,6 +95,111 @@ describe('MCP Server', () => {
     });
 
     expect(result.isError).toBe(true);
+
+    await mcpClient.close();
+  });
+
+  it('get_tasks without projectId includes inbox tasks', async () => {
+    const server = new McpServer({ name: 'ticktick-mcp', version: '0.1.0' });
+    const mockClient = createMockClient();
+
+    mockClient.getProjects.mockResolvedValue([{ id: 'p1', name: 'Work' }]);
+    mockClient.getProjectData.mockImplementation(async (projectId: string) => {
+      if (projectId === 'p1') {
+        return {
+          project: { id: 'p1', name: 'Work' },
+          tasks: [{ id: 't1', title: 'Work task', projectId: 'p1', status: 0, tags: [], priority: 0 }],
+        };
+      }
+      if (projectId === 'inbox123') {
+        return {
+          project: { id: 'inbox123', name: 'Inbox' },
+          tasks: [{ id: 't2', title: 'Inbox task', projectId: 'inbox123', status: 0, tags: [], priority: 0 }],
+        };
+      }
+      return { project: { id: projectId, name: 'Unknown' }, tasks: [] };
+    });
+    mockClient.getInboxProjectId.mockResolvedValue('inbox123');
+
+    registerTaskTools(server, mockClient as any);
+    registerProjectTools(server, mockClient as any);
+
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    await server.connect(serverTransport);
+    const mcpClient = new Client({ name: 'test-client', version: '1.0' });
+    await mcpClient.connect(clientTransport);
+
+    const result = await mcpClient.callTool({
+      name: 'ticktick_get_tasks',
+      arguments: {},
+    });
+
+    expect(result.isError).toBeFalsy();
+    const text = (result.content as Array<{ type: string; text: string }>)[0].text;
+    const parsed = JSON.parse(text);
+    const titles = parsed.tasks.map((t: any) => t.title);
+    expect(titles).toContain('Work task');
+    expect(titles).toContain('Inbox task');
+
+    await mcpClient.close();
+  });
+
+  it('get_tasks with explicit projectId does NOT fetch inbox', async () => {
+    const server = new McpServer({ name: 'ticktick-mcp', version: '0.1.0' });
+    const mockClient = createMockClient();
+    mockClient.getProjectData.mockResolvedValue({
+      project: { id: 'p1', name: 'Work' },
+      tasks: [{ id: 't1', title: 'Work task', projectId: 'p1', status: 0, tags: [], priority: 0 }],
+    });
+
+    registerTaskTools(server, mockClient as any);
+    registerProjectTools(server, mockClient as any);
+
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    await server.connect(serverTransport);
+    const mcpClient = new Client({ name: 'test-client', version: '1.0' });
+    await mcpClient.connect(clientTransport);
+
+    const result = await mcpClient.callTool({
+      name: 'ticktick_get_tasks',
+      arguments: { projectId: 'p1' },
+    });
+
+    expect(result.isError).toBeFalsy();
+    expect(mockClient.getInboxProjectId).not.toHaveBeenCalled();
+
+    await mcpClient.close();
+  });
+
+  it('get_tasks degrades gracefully if inbox discovery fails', async () => {
+    const server = new McpServer({ name: 'ticktick-mcp', version: '0.1.0' });
+    const mockClient = createMockClient();
+    mockClient.getProjects.mockResolvedValue([{ id: 'p1', name: 'Work' }]);
+    mockClient.getProjectData.mockResolvedValue({
+      project: { id: 'p1', name: 'Work' },
+      tasks: [{ id: 't1', title: 'Work task', projectId: 'p1', status: 0, tags: [], priority: 0 }],
+    });
+    mockClient.getInboxProjectId.mockRejectedValue(new Error('Discovery failed'));
+
+    registerTaskTools(server, mockClient as any);
+    registerProjectTools(server, mockClient as any);
+
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    await server.connect(serverTransport);
+    const mcpClient = new Client({ name: 'test-client', version: '1.0' });
+    await mcpClient.connect(clientTransport);
+
+    const result = await mcpClient.callTool({
+      name: 'ticktick_get_tasks',
+      arguments: {},
+    });
+
+    expect(result.isError).toBeFalsy();
+    const text = (result.content as Array<{ type: string; text: string }>)[0].text;
+    const parsed = JSON.parse(text);
+    expect(parsed.tasks).toHaveLength(1);
+    expect(parsed.tasks[0].title).toBe('Work task');
+    expect(parsed.warnings.some((w: string) => w.toLowerCase().includes('inbox'))).toBe(true);
 
     await mcpClient.close();
   });

--- a/tests/unit/client.test.ts
+++ b/tests/unit/client.test.ts
@@ -6,12 +6,17 @@ describe('TickTickClient', () => {
     getValidAccessToken: vi.fn().mockResolvedValue('test-token'),
     forceRefresh: vi.fn().mockResolvedValue('refreshed-token'),
   };
+  const mockKeychain = {
+    get: vi.fn().mockResolvedValue(null),
+    set: vi.fn().mockResolvedValue(undefined),
+    remove: vi.fn().mockResolvedValue(undefined),
+  };
   const mockFetch = vi.fn();
   let client: TickTickClient;
 
   beforeEach(() => {
     vi.clearAllMocks();
-    client = new TickTickClient(mockTokenManager as any, mockFetch as any);
+    client = new TickTickClient(mockTokenManager as any, mockKeychain, mockFetch as any);
   });
 
   describe('request', () => {

--- a/tests/unit/get-tasks-warnings.test.ts
+++ b/tests/unit/get-tasks-warnings.test.ts
@@ -106,10 +106,8 @@ describe('ticktick_get_tasks — warnings for data loss (issues #3 and #4)', () 
             });
           }
           if (projectId === 'inbox000') {
-            return Promise.resolve({
-              project: { id: 'inbox000', name: 'Inbox' },
-              tasks: [],
-            });
+            // Real TickTick API returns { tasks: [...] } without project wrapper for inbox
+            return Promise.resolve({ tasks: [] });
           }
           // p2 returns invalid project data (missing project field)
           return Promise.resolve({ garbage: true });
@@ -191,7 +189,10 @@ describe('ticktick_get_tasks — warnings for data loss (issues #3 and #4)', () 
               tasks: [validTask('t2', 'p2'), invalidTask(), invalidTask()],
             });
           }
-          // Inbox and other projects return empty
+          if (projectId === 'inbox000') {
+            // Real TickTick API returns { tasks: [...] } without project wrapper for inbox
+            return Promise.resolve({ tasks: [] });
+          }
           return Promise.resolve({
             project: { id: projectId, name: 'Empty' },
             tasks: [],
@@ -218,10 +219,8 @@ describe('ticktick_get_tasks — warnings for data loss (issues #3 and #4)', () 
         ]),
         getProjectData: vi.fn().mockImplementation((projectId: string) => {
           if (projectId === 'inbox000') {
-            return Promise.resolve({
-              project: { id: 'inbox000', name: 'Inbox' },
-              tasks: [],
-            });
+            // Real TickTick API returns { tasks: [...] } without project wrapper for inbox
+            return Promise.resolve({ tasks: [] });
           }
           return Promise.resolve({ garbage: true });
         }),

--- a/tests/unit/inbox-discovery.test.ts
+++ b/tests/unit/inbox-discovery.test.ts
@@ -1,0 +1,217 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { TickTickClient } from '../../src/ticktick-client.js';
+
+function createMockKeychain() {
+  const store = new Map<string, string>();
+  return {
+    get: vi.fn(async (account: string) => store.get(account) ?? null),
+    set: vi.fn(async (account: string, value: string) => { store.set(account, value); }),
+    remove: vi.fn(async (account: string) => { store.delete(account); }),
+    _store: store,
+  };
+}
+
+function createMockTokenManager() {
+  return {
+    getValidAccessToken: vi.fn().mockResolvedValue('test-token'),
+    forceRefresh: vi.fn().mockResolvedValue('refreshed-token'),
+  };
+}
+
+describe('TickTickClient.getInboxProjectId', () => {
+  let mockFetch: ReturnType<typeof vi.fn>;
+  let mockKeychain: ReturnType<typeof createMockKeychain>;
+  let mockTokenManager: ReturnType<typeof createMockTokenManager>;
+  let client: TickTickClient;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFetch = vi.fn();
+    mockKeychain = createMockKeychain();
+    mockTokenManager = createMockTokenManager();
+    client = new TickTickClient(mockTokenManager as any, mockKeychain, mockFetch as any);
+  });
+
+  it('returns cached inbox ID from memory on subsequent calls', async () => {
+    // First call: keychain has it
+    mockKeychain._store.set('inbox_id', 'inbox123');
+    const first = await client.getInboxProjectId();
+    const second = await client.getInboxProjectId();
+
+    expect(first).toBe('inbox123');
+    expect(second).toBe('inbox123');
+    // Keychain.get should only be called once (first call), second uses memory cache
+    expect(mockKeychain.get).toHaveBeenCalledTimes(1);
+  });
+
+  it('reads inbox ID from keychain when not in memory', async () => {
+    mockKeychain._store.set('inbox_id', 'inbox456');
+
+    const result = await client.getInboxProjectId();
+    expect(result).toBe('inbox456');
+    expect(mockKeychain.get).toHaveBeenCalledWith('inbox_id');
+    // No API calls needed
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('discovers inbox ID via probe task when not cached', async () => {
+    // First call: create task (returns inbox ID in projectId)
+    // Second call: complete the probe task
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        text: () => Promise.resolve(JSON.stringify({
+          id: 'probe-task-id',
+          title: '__ticktick_mcp_inbox_probe__',
+          projectId: 'inbox789',
+        })),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        text: () => Promise.resolve(''),
+      });
+
+    const result = await client.getInboxProjectId();
+
+    expect(result).toBe('inbox789');
+    // Should have created a probe task
+    expect(mockFetch).toHaveBeenCalledWith(
+      'https://api.ticktick.com/open/v1/task',
+      expect.objectContaining({
+        method: 'POST',
+        body: expect.stringContaining('__ticktick_mcp_inbox_probe__'),
+      }),
+    );
+    // Should have completed the probe task
+    expect(mockFetch).toHaveBeenCalledWith(
+      'https://api.ticktick.com/open/v1/project/inbox789/task/probe-task-id/complete',
+      expect.objectContaining({ method: 'POST' }),
+    );
+    // Should have persisted to keychain
+    expect(mockKeychain.set).toHaveBeenCalledWith('inbox_id', 'inbox789');
+  });
+
+  it('caches discovered inbox ID in keychain for persistence', async () => {
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        text: () => Promise.resolve(JSON.stringify({
+          id: 'probe-id',
+          projectId: 'inbox999',
+        })),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        text: () => Promise.resolve(''),
+      });
+
+    await client.getInboxProjectId();
+
+    expect(mockKeychain.set).toHaveBeenCalledWith('inbox_id', 'inbox999');
+  });
+
+  it('still caches inbox ID even if probe task cleanup fails', async () => {
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        text: () => Promise.resolve(JSON.stringify({
+          id: 'probe-id',
+          projectId: 'inbox555',
+        })),
+      })
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+        headers: { get: () => null },
+        text: () => Promise.resolve('Internal Server Error'),
+      });
+
+    // Should NOT throw — cleanup failure is non-fatal
+    const result = await client.getInboxProjectId();
+    expect(result).toBe('inbox555');
+    expect(mockKeychain.set).toHaveBeenCalledWith('inbox_id', 'inbox555');
+  });
+
+  it('throws when probe task creation fails', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      headers: { get: () => null },
+      text: () => Promise.resolve('Internal Server Error'),
+    });
+
+    await expect(client.getInboxProjectId()).rejects.toThrow();
+  });
+
+  it('throws when probe task response has no projectId', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      text: () => Promise.resolve(JSON.stringify({
+        id: 'probe-id',
+        title: '__ticktick_mcp_inbox_probe__',
+        // no projectId field
+      })),
+    });
+
+    await expect(client.getInboxProjectId()).rejects.toThrow(/inbox/i);
+  });
+
+  it('deduplicates concurrent calls — only one probe task is created', async () => {
+    // Mock: first call creates probe task, second call completes it
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        text: () => Promise.resolve(JSON.stringify({
+          id: 'probe-id',
+          projectId: 'inbox-concurrent',
+        })),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        text: () => Promise.resolve(''),
+      });
+
+    // Fire two calls concurrently before either resolves
+    const [result1, result2] = await Promise.all([
+      client.getInboxProjectId(),
+      client.getInboxProjectId(),
+    ]);
+
+    expect(result1).toBe('inbox-concurrent');
+    expect(result2).toBe('inbox-concurrent');
+
+    // POST /task (probe creation) should only be called ONCE
+    const postTaskCalls = mockFetch.mock.calls.filter(
+      (call: any[]) =>
+        call[0] === 'https://api.ticktick.com/open/v1/task' &&
+        call[1]?.method === 'POST' &&
+        call[1]?.body?.includes('__ticktick_mcp_inbox_probe__'),
+    );
+    expect(postTaskCalls).toHaveLength(1);
+  });
+
+  it('still returns discovered ID when keychain.set fails', async () => {
+    // Mock probe task creation and completion
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        text: () => Promise.resolve(JSON.stringify({
+          id: 'probe-id',
+          projectId: 'inbox-keychain-fail',
+        })),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        text: () => Promise.resolve(''),
+      });
+
+    // Make keychain.set reject
+    mockKeychain.set.mockRejectedValueOnce(new Error('keychain write failed'));
+
+    const result = await client.getInboxProjectId();
+
+    // Should still return the discovered ID despite keychain failure
+    expect(result).toBe('inbox-keychain-fail');
+    expect(mockKeychain.set).toHaveBeenCalledWith('inbox_id', 'inbox-keychain-fail');
+  });
+});

--- a/tests/unit/tool-error-handling.test.ts
+++ b/tests/unit/tool-error-handling.test.ts
@@ -21,6 +21,7 @@ function createMockClient() {
     }),
     updateTask: vi.fn().mockResolvedValue({ id: 't1', title: 'Updated' }),
     completeTask: vi.fn().mockResolvedValue(null),
+    getInboxProjectId: vi.fn().mockResolvedValue('inbox000'),
   };
 }
 


### PR DESCRIPTION
## Summary
- Discovers the Inbox project ID via a probe task (create → read projectId → complete), with memory + keychain caching
- Includes inbox tasks in `ticktick_get_tasks` results when fetching all projects
- Includes inbox project in `ticktick_get_projects` results
- Handles the TickTick API's different response format for inbox (`{ tasks: [...] }` without `project` wrapper), which differs from regular projects (`{ project: {...}, tasks: [...] }`)

## Test plan
- [x] 98 unit/MCP tests pass, 3 integration tests skipped (no credentials in CI)
- [x] Tests cover: inbox discovery (keychain cache, probe task, concurrency dedup, error recovery), get_tasks with/without inbox, get_projects with inbox, graceful degradation on discovery failure
- [x] Tests mock the real inbox API format (no `project` wrapper) to prevent regression
- [ ] Manual verification: restart Claude Code and run `ticktick_get_tasks` — inbox tasks should appear without warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)